### PR TITLE
added httplib2 dependency; trying to make build of 0.0.3 succeed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,11 +13,13 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   host:
+    - google-auth
+    - httplib2 >=0.9.1
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,11 +18,8 @@ build:
 
 requirements:
   host:
-    - google-auth
-    - httplib2 >=0.9.1
     - pip
     - python
-    - setuptools
 
   run:
     - python


### PR DESCRIPTION
Added httplib2 dependency.  Also, the current conda-forge version of google-auth-httplib2 is 0.0.2 ; trying to make a build of 0.0.3 succeed.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
